### PR TITLE
Update swift versions

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
             targets: ["MinifyCSSPublishPlugin"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/johnsundell/publish.git", from: "0.8.0"),
+        .package(url: "https://github.com/johnsundell/publish.git", from: "0.1.0"),
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -1,16 +1,17 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.5
 
 import PackageDescription
 
 let package = Package(
     name: "MinifyCSSPublishPlugin",
+    platforms: [.macOS(.v12)],
     products: [
         .library(
             name: "MinifyCSSPublishPlugin",
             targets: ["MinifyCSSPublishPlugin"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/johnsundell/publish.git", from: "0.1.0"),
+        .package(url: "https://github.com/johnsundell/publish.git", from: "0.8.0"),
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     targets: [
         .target(
             name: "MinifyCSSPublishPlugin",
-            dependencies: ["Publish"]),
+            dependencies: [.product(name: "Publish", package: "publish")]),
         .testTarget(
             name: "MinifyCSSPublishPluginTests",
             dependencies: ["MinifyCSSPublishPlugin"]),


### PR DESCRIPTION
This will use a more modern version of Swift and also a newer version of Publish.

With these changes the plugin should work just fine for any newly created Publish project.